### PR TITLE
Fix logo alignment

### DIFF
--- a/static/sass/_patterns_navigation.scss
+++ b/static/sass/_patterns_navigation.scss
@@ -14,7 +14,7 @@
 
         > a {
           display: inline-block;
-          padding: 1rem .75rem !important;
+          padding: .85rem 1.25rem !important;
         }
       }
 


### PR DESCRIPTION
## Done
Updated the large screen list items padding.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8019/](http://0.0.0.0:8019/)
- See that the logo now aligns centrally with the navigation banner


## Issue / Card
Fixes https://github.com/canonical-websites/community.ubuntu.com/issues/1

## Screenshots

![ubuntu community - ubuntu community 2](https://user-images.githubusercontent.com/1413534/26920929-6b06c52a-4c32-11e7-973c-97e97ca45511.png)
