### PR TITLE
Fix w3c validator warning on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<div class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
       <blockquote class="p-pull-quote">
@@ -49,7 +49,7 @@
       </blockquote>
     </div>
   </div>
-</section>
+</div>
 
 <section class="p-strip is-deep is-bordered">
   <div class="row">


### PR DESCRIPTION
## Done
Change the non-section to a `div` on the homepage as it doesn't contain a heading.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8019/](http://0.0.0.0:8019/))
- Validate the HTML and check there are no warnings


## Issue / Card
Fixes https://github.com/canonical-websites/community.ubuntu.com/issues/7