### PR TITLE
Update the footer copyright content

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -1,6 +1,6 @@
 <footer class="p-footer p-strip">
   <div class="row">
-    &copy; {% now "Y" %} Company name and logo are registered trademarks of Company Ltd.
+    &copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are registered trademarks of <a href="http://canonical.com">Canonical Ltd</a>.
     <nav>
       <ul class="p-footer__links">
         <li class="p-footer__item">


### PR DESCRIPTION
## Done
Updated the copyright content in the footer.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8019/](http://0.0.0.0:8019/))
- Check the footer content is correct

__The footer border is the default Vanilla one__

## Issue / Card
Fixes https://github.com/canonical-websites/community.ubuntu.com/issues/5
