### PR TITLE
Add homepage hero image

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,31 +2,28 @@
 
 {% block content %}
 
-<section class="p-strip--light is-bordered is-deep">
+<section class="p-strip--image is-bordered is-deep"
+  style="background-image:url('https://assets.ubuntu.com/v1/4aedbaa8-Raring_Group_Photo.jpg')">
   <div class="row">
     <div class="col-8">
-      <h1>Community</h1>
-      <p>
-        Whether you&rsquo;re an experienced technology user or you&rsquo;re
-        just getting started, there are lots of ways to get involved with the
-        Ubuntu community. Ubuntu is more than an operating system for your
-        computer, server, cloud, phone, tablet, or TV. It&rsquo;s also a
-        massively collaborative project. Ubuntu is always open and looking
-        for ways to create the best possible experience for anyone who tries
-        it and community participation is a great way to help make that happen.
-      </p>
-      <p>
-        <a href="/contribute/find-a-task/" class="p-button--brand">
-          Find a task
-        </a>
-        to start contributing right away.
-      </p>
-      <p>
-        Whether you participate in Ubuntu locally with people in your city or
-        town, or you collaborate online with other people that enjoy making
-        Ubuntu, you will be amazed by the people you meet and their passion
-        for doing something startling.
-      </p>
+      <div class="p-card--overlay">
+        <h1>Community</h1>
+        <p>
+          Whether you&rsquo;re an experienced technology user or you&rsquo;re
+          just getting started, there are lots of ways to get involved with the
+          Ubuntu community. Ubuntu is more than an operating system for your
+          computer, server, cloud, phone, tablet, or TV. It&rsquo;s also a
+          massively collaborative project. Ubuntu is always open and looking
+          for ways to create the best possible experience for anyone who tries
+          it and community participation is a great way to help make that happen.
+        </p>
+        <p>
+          <a href="/contribute/find-a-task/" class="p-button--brand">
+            Find a task
+          </a>
+          to start contributing right away.
+        </p>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Make the homepage hero a strip--image.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8019/](http://0.0.0.0:8019/))
- Check that the hero has a background image

## Issue / Card
Fixes https://github.com/canonical-websites/community.ubuntu.com/issues/6

